### PR TITLE
feat: Add user confirmation to clear all canvas items

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
             <div class="dropdown-content">
                 <button onclick="centerOnContent()">Center on content</button>
                 <button onclick="toggleTheme()">Toogle theme</button>
-                <button onclick="clearAll()">Remove all</button>
+                <button onclick="clearAll(true)">Remove all</button>
             </div>
         </div>
 

--- a/userMenu.js
+++ b/userMenu.js
@@ -47,7 +47,10 @@ function addText() {
   draw();
 }
 
-function clearAll() {
+function clearAll(userConfirmed = false) {
+  if (userConfirmed && !confirm("Are you sure you want to clear the canvas?")) {
+    return;
+  }
   listToDraw = [];
   updateList();
   draw();
@@ -55,7 +58,7 @@ function clearAll() {
 
 function newDocument() {
   document.getElementById("documentName").value = "New Document";
-  clearAll();
+  clearAll(false);
 }
 
 function saveDataToFile() {


### PR DESCRIPTION
The changes made in this commit add a user confirmation dialog when the
"Remove all" button is clicked in the dropdown menu. Previously, the
`clearAll()` function would immediately clear the canvas without asking
the user for confirmation. Now, the function checks if the `userConfirmed`
parameter is set to `true` before proceeding with the canvas clear
operation. If the parameter is not set, the function will display a
confirmation dialog to the user before clearing the canvas.

Additionally, the `newDocument()` function has been updated to pass
`false` as the `userConfirmed` parameter when calling `clearAll()`, ensuring
that the user is not prompted for confirmation when creating a new
document.