### PR TITLE
feat: Add context menu functionality

### DIFF
--- a/index.css
+++ b/index.css
@@ -37,6 +37,18 @@ body {
     left: 0px;
 }
 
+#context-menu {
+    position: absolute;
+    display: none;
+    flex-direction: column;
+    background: var(--secondary);
+    color: var(--text);
+    padding: 5px;
+    border-radius: 5px;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+    user-select: none;
+}
+
 #controls {
     padding: 10px;
     background: var(--secondary);

--- a/index.html
+++ b/index.html
@@ -80,6 +80,12 @@
         </div>
     </div>
 
+    <div id="context-menu">
+        <button onclick="contextDelete()">Delete</button>
+        <button onclick="contextFront()">In the front</button>
+        <button onclick="contextBack()">In the back</button>
+    </div>
+
     <div id="zoom-controls">
         <button onclick="adjustZoom(-0.1)">-</button>
         <button onclick="adjustZoom(+0.1)">+</button>

--- a/userMenu.js
+++ b/userMenu.js
@@ -1,4 +1,5 @@
 let addingObject = null;
+let contextObject = null;
 
 // Main functions for canvas manipulation and export
 function centerOnContent() {
@@ -159,7 +160,7 @@ function addItemToList(element) {
   newItem.setAttribute("data-id", element.id);
 
   newItem.innerHTML = `
-    <input value="Element ${element.id}" size="8">
+    <input value="${element.id}" size="8">
     <button class="move-btn move-up-btn">⏫</button>
     <button class="move-btn move-down-btn">⏬</button>
     <button class="delete-btn">Delete</button>
@@ -294,6 +295,54 @@ function hideAddMenu() {
   choosePoint = false;
   connectPoints = false;
   connectPointLocation = null;
+}
+
+function contextDelete() {
+  if (contextObject != null) {
+    listToDraw = listToDraw.filter((item) => item.id != contextObject.id);
+    updateListAndDraw();
+  }
+  hideContextMenu();
+}
+
+function contextFront() {
+  if (contextObject != null) {
+    listToDraw = listToDraw.filter((item) => item.id != contextObject.id);
+    listToDraw.push(contextObject);
+    updateListAndDraw();
+  }
+  hideContextMenu();
+}
+
+function contextBack() {
+  if (contextObject != null) {
+    listToDraw = listToDraw.filter((item) => item.id != contextObject.id);
+    listToDraw.unshift(contextObject);
+    updateListAndDraw();
+  }
+  hideContextMenu();
+}
+
+function showContextMenu(x, y, object) {
+  let contextMenu = document.getElementById("context-menu");
+  contextMenu.style.display = "flex";
+  contextMenu.style.left = x + "px";
+  contextMenu.style.top = y + "px";
+  contextObject = object;
+
+  // if the menu would be outside of the window, move it inside
+  if (contextMenu.getBoundingClientRect().right > window.innerWidth) {
+    contextMenu.style.left = window.innerWidth - contextMenu.offsetWidth + "px";
+  }
+  if (contextMenu.getBoundingClientRect().bottom > window.innerHeight) {
+    contextMenu.style.top = window.innerHeight - contextMenu.offsetHeight + "px";
+  }
+}
+
+function hideContextMenu() {
+  let contextMenu = document.getElementById("context-menu");
+  contextMenu.style.display = "none";
+  contextObject = null;
 }
 
 function checkForUpdates() {


### PR DESCRIPTION
This commit adds the ability to show a context menu when
right-clicking on an element in the canvas. The context
menu allows the user to delete the element, move it to
the front, or move it to the back. The commit also includes
changes to the CSS to style the context menu.

The most important changes are:

- Addition of `contextDelete()`, `contextFront()`, and `contextBack()`
  functions to handle the context menu actions
- Addition of `showContextMenu()` and `hideContextMenu()` functions to
  show and hide the context menu
- Addition of CSS styles for the context menu