### PR TITLE
feat: Ensure empty inputs are set to zero

### DIFF
--- a/canvas.js
+++ b/canvas.js
@@ -331,6 +331,16 @@ function onPointerUp(e) {
       }
     }
 
+    // if one of the inputs is empty, add a zero
+    if (addingObject instanceof Pointer) {
+      if (addingObject.length == "") {
+        addingObject.length = "0";
+      }
+      if (addingObject.angle == "") {
+        addingObject.angle = "0";
+      }
+    }
+
     listToDraw.push(addingObject);
     hideAddMenu();
 

--- a/userMenu.js
+++ b/userMenu.js
@@ -421,7 +421,6 @@ function checkForUpdates() {
   fetch("https://api.github.com/repos/2Friendly4You/PointerDiagram/releases")
     .then((response) => response.json())
     .then((data) => {
-      console.log(data);
       let latest = data[0].tag_name;
       // delete everything except numbers and dots
       latest = latest.replace(/[^0-9.]/g, "");
@@ -536,8 +535,6 @@ hideAddMenu();
 
 // wait for the page to load
 document.addEventListener("DOMContentLoaded", () => {
-  console.log("Page loaded");
-
   // load data from local storage
   let loadedList = localStorage.getItem("listToDraw");
   if (loadedList) {


### PR DESCRIPTION
The changes in this commit ensure that if an input for the "length" or
"angle" properties of an "addingObject" is empty, it is set to "0"
instead. This is to provide a better user experience and handle edge
cases where the user may have left these fields blank.

The changes are focused on the `onPointerUp` function in `canvas.js`,
where the new logic is added to check for empty inputs and set them to
zero.

In `userMenu.js`, the unnecessary `console.log` statements have been
removed, as they are no longer needed and can clutter the console.